### PR TITLE
chore: point DESCRIPTION URL at extendr.rs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,7 +21,7 @@ Depends:
     R (>= 4.2)
 Imports: 
     rlang (>= 1.1.0)
-URL: https://extendr.github.io/tomledit/, https://github.com/extendr/tomledit
+URL: https://extendr.rs/tomledit/, https://github.com/extendr/tomledit
 BugReports: https://github.com/extendr/tomledit/issues
 Suggests: 
     testthat (>= 3.0.0)

--- a/man/tomledit-package.Rd
+++ b/man/tomledit-package.Rd
@@ -11,7 +11,7 @@ A toolkit for working with 'TOML' files in R while preserving formatting, commen
 \seealso{
 Useful links:
 \itemize{
-  \item \url{https://extendr.github.io/tomledit/}
+  \item \url{https://extendr.rs/tomledit/}
   \item \url{https://github.com/extendr/tomledit}
   \item Report bugs at \url{https://github.com/extendr/tomledit/issues}
 }


### PR DESCRIPTION
**TODO: replace this line with your own framing, in your own voice.**

<details>
<summary><h3>AI-written details</h3></summary>

## Summary
- `DESCRIPTION`: `URL:` now uses `https://extendr.rs/tomledit/` instead of `https://extendr.github.io/tomledit/`.
- `man/tomledit-package.Rd`: updated the matching `\url{}` in the "Useful links" block (roxygen output from the `URL:` field), hand-edited so `RoxygenNote:` and unrelated `.Rd` files stay untouched.
- Closes #3.

## Why this diff does not match the issue text
Issue #3 (Feb 2025) asked to change `https://josiahparry.github.io/tomledit/`, and that specific change already landed in 7fb9808. The URL has since gone stale a second time: the extendr org moved its docs to the `extendr.rs` custom domain, so the github.io address is no longer canonical.

- `https://extendr.github.io/tomledit/` returns `301 Moved Permanently` to `https://extendr.rs/tomledit/`.
- `gh api repos/extendr/tomledit/pages` reports `"html_url": "https://extendr.rs/tomledit/"`.
- `rextendr`'s `DESCRIPTION` already uses `https://extendr.rs/rextendr/`, so this matches the sibling package.

## Verification (run locally, R 4.6.0)
`urlchecker::url_check(".")`, before and after:

| | redirect findings | which |
|---|---|---|
| `main` | 3 | `extendr.github.io/tomledit/` (DESCRIPTION, man/tomledit-package.Rd) + 2 in README.md |
| this branch | 2 | the 2 in README.md |

`R CMD check --as-cran` on the built tarball: `checking Rust compilation ... OK`, `checking tests ... OK`, `checking Rd cross-references ... OK`. The `CRAN incoming feasibility` NOTE no longer mentions the tomledit docs URL. Remaining ERROR/WARNING in that run were a local LaTeX gap (`inconsolata.sty` not found) and not package defects.

Re-running `roxygen2::roxygenise()` produced **no diff** in the `\url{}` block, confirming the hand-edited `.Rd` matches generated output.

## Notes
- `README.md:7` and `README.md:13` still link to `https://extendr.github.io/` and `https://extendr.github.io/extendr/extendr_api/`, both of which 301 to `extendr.rs`. Because `README.md` is not in `.Rbuildignore` it ships in the tarball, so `R CMD check --as-cran` attributes those to tomledit and NOTEs them. This is pre-existing on `main`, not introduced here, and is left out to keep this PR scoped to #3. Fixing those two (plus their `README.qmd` mirrors, hand-edited so re-rendering does not restamp the embedded example dates) would take the count to 0. Happy to fold it in or send it separately, whichever you prefer.
- `_pkgdown.yml:1` still has `url: https://extendr.github.io/tomledit/`. Left alone deliberately: it changes canonical-link and sitemap output on a live site, and `rextendr` currently has the same DESCRIPTION/`_pkgdown.yml` split without build problems.

---
_Drafted by Claude (claude-opus-5). Reviewed by the author._

</details>
