### PR TITLE
chore: finish the extendr.rs URL move (README, pkgdown)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@
 
 <!-- badges: start -->
 [![R-CMD-check](https://github.com/extendr/tomledit/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/extendr/tomledit/actions/workflows/R-CMD-check.yaml)
-[![extendr](https://img.shields.io/badge/extendr-%5E0.7.1-276DC2)](https://extendr.github.io/extendr/extendr_api/)
+[![extendr](https://img.shields.io/badge/extendr-%5E0.7.1-276DC2)](https://extendr.rs/extendr/extendr_api/)
 <!-- badges: end -->
 
 Create or edit TOML documents from R using `tomledit`.
 
 `tomledit` is written in Rust using
-[extendr](https://extendr.github.io/) and the
+[extendr](https://extendr.rs/) and the
 [`toml_edit`](https://docs.rs/toml_edit/) crate.
 
 ## Installation

--- a/README.qmd
+++ b/README.qmd
@@ -6,12 +6,12 @@ format: gfm
 
  <!-- badges: start -->
   [![R-CMD-check](https://github.com/extendr/tomledit/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/extendr/tomledit/actions/workflows/R-CMD-check.yaml)
-  [![extendr](https://img.shields.io/badge/extendr-^0.7.1-276DC2)](https://extendr.github.io/extendr/extendr_api/)
+  [![extendr](https://img.shields.io/badge/extendr-^0.7.1-276DC2)](https://extendr.rs/extendr/extendr_api/)
   <!-- badges: end -->
 
 Create or edit TOML documents from R using `tomledit`. 
 
-`tomledit` is written in Rust using [extendr](https://extendr.github.io/) and the [`toml_edit`](https://docs.rs/toml_edit/) crate. 
+`tomledit` is written in Rust using [extendr](https://extendr.rs/) and the [`toml_edit`](https://docs.rs/toml_edit/) crate. 
 
 ## Installation 
 

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,4 +1,4 @@
-url: https://extendr.github.io/tomledit/
+url: https://extendr.rs/tomledit/
 template:
   bootstrap: 5
 


### PR DESCRIPTION
**TODO: replace this line with your own framing, in your own voice.**

<details>
<summary><h3>AI-written details</h3></summary>

## Summary
Finishes the `extendr.github.io` to `extendr.rs` move that #10 started on `DESCRIPTION`. Two commits, deliberately separate because they carry different risk:

- `d39bac9` **README** (`README.md:7,13` and the `README.qmd:9,14` mirrors). Clears a real `R CMD check --as-cran` NOTE.
- `2d57150` **pkgdown** (`_pkgdown.yml:1`). Cosmetic on its own, but changes canonical-link and `sitemap.xml` output on the live site.

Drop either commit without unpicking the other if you only want one.

## Why the README change matters
`README.md` is not in `.Rbuildignore`, so it ships in the tarball and CRAN attributes its links to tomledit. Both old URLs 301-redirect, and `R CMD check --as-cran` on current `main` reports:

```
Found the following (possibly) invalid URLs:
  URL: https://extendr.github.io/ (moved to https://extendr.rs/)
    From: README.md
    Status: 301
  URL: https://extendr.github.io/extendr/extendr_api/ (moved to https://extendr.rs/extendr/extendr_api/)
    From: README.md
    Status: 301
```

This is pre-existing on `main`, not a regression from #10.

`README.md` was hand-edited rather than re-rendered from `README.qmd`. A re-render would restamp the embedded example output dates (7fb9808 shows that happening: `date = 2025-02-20` became `2025-03-03`), which would bury a 2-line URL fix in unrelated churn.

## Verification (local, R 4.6.0)
`R CMD check --as-cran` on the built tarball is down to **`Status: 2 NOTEs`**, with no invalid-URL findings at all. What remains is unrelated to this PR:

- `CRAN incoming feasibility` now contains only `Version contains large components (0.1.1.9000)`, expected for a dev version.
- `checking for hidden files and directories` picks up a local `.claude/` directory in my working tree. It does not exist in a fresh checkout, so CI will not see it.

`urlchecker::url_check(".")` goes from 2 findings to **0**. Scope note: urlchecker reads `DESCRIPTION`, `man/`, `README.md` and `NEWS.md`, so that 0 validates the `README.md` lines specifically. The `README.qmd` edit is source-sync only (it is `.Rbuildignore`d and never checked), and `_pkgdown.yml` is not in urlchecker's scope either. It parses cleanly to `url: https://extendr.rs/tomledit/` and the `pkgdown` workflow job is the real check on it.

## Noticed but deliberately not changed
The extendr badge label reads `extendr-^0.7.1` while `src/rust/Cargo.toml:13` pins `extendr-api = "0.8.2"`. Only the badge's link target was touched here, not the version it asserts, since whether that should track Cargo.toml or advertise a supported floor is your call. Happy to bump it if you want.

---
_Drafted by Claude (claude-opus-5). Reviewed by the author._

</details>
